### PR TITLE
Add README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License (Modified)
+
+Copyright (c) 2020 DauInvest
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. WE DO NOT ACCEPT ANY RESPONSIBILITY FOR YOUR CLAIMS.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+## Flext
+
+Flext is a lightweight extension over Handlebars. It introduces a small DSL for handling macros and modules to help create dynamic templates. The library is compiled to both ESM and CommonJS bundles and can be embedded in other projects such as Vue components.
+
+Public documentation is available at [TrustMe Wiki](https://trustmekz.atlassian.net/wiki/external/MTUwYzM5NjUzNDE4NDViMGJlMTliOWEzNzM1Y2RiZWE).
+
+Flext is maintained by **DauInvest** (Astana, Kazakhstan).
+
+### Example
+```ts
+import { Flext } from '@trustme24/flext';
+
+const template = `
+{{!-- @use "put" --}}
+<td>{{ put data.name 'Guest' }}</td>
+`;
+
+const fx = new Flext(template, { data: { name: 'Kenny' } });
+console.log(fx.html); // <td><span class="text-blue-500">Kenny</span></td>
+```
+
+## Installation
+
+```bash
+npm install @trustme24/flext
+```

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ document.body.innerHTML = flext.html;
 
 ## Installation
 
-1. Install dependencies:
+1. Install **dependencies**:
 
 ```shell
 npm install tailwindcss
 npm i @trustme24/flext
 ```
 
-2. Add the CSS import:
+2. Add the **CSS** import:
 
 Add `@import "@trustme24/flext/index.css";` in `src/index.css`.
 
-3. You're all set!
+3. **You're all set!**

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## Flext
 
-Flext is a lightweight extension over Handlebars. It introduces a small DSL for handling macros and modules to help create dynamic templates. The library is compiled to both ESM and CommonJS bundles and can be embedded in other projects such as Vue components.
+**Flext** is a lightweight extension over Handlebars. It introduces a small DSL for handling macros and modules to help create dynamic templates. The library is compiled to both ESM and CommonJS bundles and can be embedded in other projects such as [Vue components](https://www.npmjs.com/package/vue-flext).
 
-Public documentation is available at [TrustMe Wiki](https://trustmekz.atlassian.net/wiki/external/MTUwYzM5NjUzNDE4NDViMGJlMTliOWEzNzM1Y2RiZWE).
+Public documentation is available at [Wiki](https://trustmekz.atlassian.net/wiki/external/MTUwYzM5NjUzNDE4NDViMGJlMTliOWEzNzM1Y2RiZWE).
 
-Flext is maintained by **DauInvest** (Astana, Kazakhstan).
+Flext is maintained by [TrustMe](https://trustme24.com/).
 
 ### Example
 ```ts
@@ -29,12 +29,17 @@ document.body.innerHTML = flext.html;
 1. Install **dependencies**:
 
 ```shell
-npm install tailwindcss
-npm i @trustme24/flext
+npm i tailwindcss @trustme24/flext
 ```
 
-2. Add the **CSS** import:
+2. Add the **CSS** import in your CSS file:
 
-Add `@import "@trustme24/flext/index.css";` in `src/index.css`.
+```css
+@import "@trustme24/flext/index.css";
+```
 
 3. **You're all set!**
+
+---
+**Flext by Kenny Romanov**  
+TrustMe

--- a/README.md
+++ b/README.md
@@ -11,16 +11,30 @@ Flext is maintained by **DauInvest** (Astana, Kazakhstan).
 import { Flext } from '@trustme24/flext';
 
 const template = `
-{{!-- @use "put" --}}
-<td>{{ put data.name 'Guest' }}</td>
+  {{!-- @v "1.0" --}}
+  {{!-- @use "put" --}}
+
+  <div class="text-center text-red-500">{{ put data.helloworld 'No Hello World...' }}</div>
 `;
 
-const fx = new Flext(template, { data: { name: 'Kenny' } });
-console.log(fx.html); // <td><span class="text-blue-500">Kenny</span></td>
+const flext = new Flext(template, {
+  data: { helloworld: 'Hello World!' },
+});
+
+document.body.innerHTML = flext.html;
 ```
 
 ## Installation
 
-```bash
-npm install @trustme24/flext
+1. Install dependencies:
+
+```shell
+npm install tailwindcss
+npm i @trustme24/flext
 ```
+
+2. Add the CSS import:
+
+Add `@import "@trustme24/flext/index.css";` in `src/index.css`.
+
+3. You're all set!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trustme24/flext",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A Powerful Templating Engine",
   "keywords": ["templates", "templating engine", "modular templates", "handlebars"],
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- document Flext usage in README with example and link to docs
- add a permissive MIT-style license

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68661b886e788332904b339d300192ae